### PR TITLE
Various sorting improvements.

### DIFF
--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -1,8 +1,27 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import cloudscraper
 import time, os, sys, re, json
 
-A_VERSION = "0.1.5"
+A_VERSION = "0.1.6"
+
+
+def chapter_key(c):
+	try:
+		n = int(float(c[0]))
+		return (n, c)
+	except:
+		return ("no_chapter", c)
+
+
+def pad_filename(s):
+	a = s.split('.')
+	try:
+		n = int(a[0])
+		a[0] = a[0].zfill(5)
+	except:
+		pass
+	return '.'.join(a)
+
 
 def dl(manga_id, lang_code="gb"):
 	# grab manga info json from api
@@ -44,7 +63,7 @@ def dl(manga_id, lang_code="gb"):
 		chapter_group = manga["chapter"][chapter_id]["group_name"]
 		if chapter_num in requested_chapters and manga["chapter"][chapter_id]["lang_code"] == lang_code:
 			chaps_to_dl.append((str(chapter_num).replace(".0",""), chapter_id, chapter_group))
-	chaps_to_dl.sort()
+	chaps_to_dl.sort(key=chapter_key)
 
 	if len(chaps_to_dl) == 0:
 		print("No chapters available to download!")
@@ -73,7 +92,8 @@ def dl(manga_id, lang_code="gb"):
 			dest_folder = os.path.join(os.getcwd(), "download", title, "c{} [{}]".format(chapter_id[0].zfill(3), groupname))
 			if not os.path.exists(dest_folder):
 				os.makedirs(dest_folder)
-			outfile = os.path.join(dest_folder, filename)
+			dest_filename = pad_filename(filename)
+			outfile = os.path.join(dest_folder, dest_filename)
 
 			r = scraper.get(url)
 			if r.status_code == 200:

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -10,7 +10,7 @@ def chapter_key(c):
 		n = int(float(c[0]))
 		return (n, c)
 	except:
-		return ("no_chapter", c)
+		return (1000000000, c)
 
 
 digits_pat = re.compile('(\d+)');

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -13,14 +13,14 @@ def chapter_key(c):
 		return ("no_chapter", c)
 
 
+digits_pat = re.compile('(\d+)');
+
 def pad_filename(s):
-	a = s.split('.')
-	try:
-		n = int(a[0])
-		a[0] = a[0].zfill(5)
-	except:
-		pass
-	return '.'.join(a)
+	m = digits_pat.search(s)
+	if m:
+		return s[:m.start()] + m.group(1).zfill(5) + s[m.end():]
+	else:
+		return s
 
 
 def dl(manga_id, lang_code="gb"):


### PR DESCRIPTION
Hi frozenpandaman,

I've enjoyed using your script and made a few small improvements to it.  Here's an explanation of what I did:

1.  On some computers (like my Mac, even though it's running the newest OS X) saying "#!/usr/bin/env python" will default to running python 2, which isn't what you want.  Saying python3 instead avoids the problem.

2.  Using the chapter_key function to sort the chapters makes it so the chapters are downloaded in numerical order.  I changed that because it's annoying to have chapters show up like (1, 10, 100, 101, 102, ...) when one is trying to read a comic from the beginning while the whole thing is downloading.

3. The pad_filename function changes the filenames of the pictures be all the same length, starting with zeroes, just like you did with the chapter IDs.  This way, 00009.jpg ends up *before* 00010.jpg when the user views the files in sorted order, rather than after it, like it would if they were named 9.jpg and 10.jpg.  That way when they user selects all the files and opens them, they'll show up in the correct order.

4. These changes seemed large enough to justify increasing the version number (especially since change #3 changes the file names of all the pictures.)

Best wishes,
-mherreshoff