### PR TITLE
Allow for downloading oneshots

### DIFF
--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -92,28 +92,20 @@ def dl(manga_id, lang_code):
 				chapters[id] = chapter
 
 	requested_chapters = prompt_chapters(chapters)
-	# temporary compatability
-	requested_chapters = [chapter["chapter"] for chapter in requested_chapters .values()]
 
 	# find out which are availble to dl
-	chaps_to_dl = []
-	for chapter_id in manga["chapter"]:
-		try:
-			chapter_num = str(float(manga["chapter"][str(chapter_id)]["chapter"])).replace(".0","")
-		except:
-			pass # Oneshot
-		chapter_group = manga["chapter"][chapter_id]["group_name"]
-		if chapter_num in requested_chapters and manga["chapter"][chapter_id]["lang_code"] == lang_code:
-			chaps_to_dl.append((str(chapter_num), chapter_id, chapter_group))
-	chaps_to_dl.sort()
+	chapters_to_download = [
+		(chapter["chapter"], id, chapter["group_name"])
+		for id, chapter in requested_chapters.items()
+	]
 
-	if len(chaps_to_dl) == 0:
+	if len(chapters_to_download) == 0:
 		print("No chapters available to download!")
 		exit(0)
 
 	# get chapter(s) json
 	print()
-	for chapter_id in chaps_to_dl:
+	for chapter_id in chapters_to_download:
 		print("Downloading chapter {}...".format(chapter_id[0]))
 		r = scraper.get("https://mangadex.org/api/chapter/{}/".format(chapter_id[1]))
 		chapter = json.loads(r.text)

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -29,7 +29,7 @@ def prompt_chapters(chapters):
 	)
 
 	print("Available chapters:")
-	print(", ".join(chapter_numbers))
+	print(" " + ", ".join(chapter_numbers))
 
 	# i/o for chapters to download
 	requested_chapters = []
@@ -72,7 +72,7 @@ def prompt_oneshots(oneshots):
 	print("Available oneshots:")
 
 	for index, oneshot in enumerate(oneshots_by_index):
-		print("  {}: {}".format(index + 1, oneshot[1]["title"]))
+		print(" {}: {}".format(index + 1, oneshot[1]["title"]))
 
 	print()
 
@@ -161,6 +161,8 @@ def dl(manga_id, lang_code):
 
 	if (len(chapters) > 0):
 		chapters_to_download.update(prompt_chapters(chapters))
+
+	print()
 
 	if (len(oneshots) > 0):
 		chapters_to_download.update(prompt_oneshots(oneshots))

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -112,7 +112,7 @@ def prompt_oneshots(oneshots):
 	return {oneshot[0]: oneshot[1] for oneshot in requested_oneshots}
 
 def get_page_urls(scraper, chapter_id):
-	r = scraper.get("https://mangadex.org/api/chapter/{}/".format(chapter_id[1]))
+	r = scraper.get("https://mangadex.org/api/chapter/{}/".format(chapter_id))
 	chapter = json.loads(r.text)
 
 	# get url list

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import cloudscraper
 import time, os, sys, re, json, html
+from collections import OrderedDict
 
 A_VERSION = "0.2"
 
@@ -64,7 +65,13 @@ def prompt_chapters(chapters):
 
 		requested_chapters.extend(s)
 
-	return {id: chapter for id, chapter in chapters.items() if chapter["chapter"] in requested_chapters}
+	return {
+		id: chapter for id, chapter in sorted(
+			chapters.items(),
+			key = lambda x: float(x[1]["chapter"])
+		)
+		if chapter["chapter"] in requested_chapters
+	}
 
 def prompt_oneshots(oneshots):
 	oneshots_by_index = [(id, chapter) for id, chapter in oneshots.items()]
@@ -157,7 +164,7 @@ def dl(manga_id, lang_code):
 			else:
 				chapters[id] = chapter
 
-	chapters_to_download = {}
+	chapters_to_download = OrderedDict()
 
 	if (len(chapters) > 0):
 		chapters_to_download.update(prompt_chapters(chapters))
@@ -172,8 +179,6 @@ def dl(manga_id, lang_code):
 		exit(0)
 
 	# get chapter(s) json
-	print()
-
 	for id, chapter in chapters_to_download.items():
 		if is_oneshot(chapter):
 			print("Downloading oneshot '{}'".format(chapter["title"]))


### PR DESCRIPTION
Since _chapters_ and _oneshots_ are semantically different, I figured simply having different prompts for each would be a decent compromise.

This did require reworking some of the logic behind how chapters are selected, however, since oneshots don't technically have chapters.

Some additional tweaks were also made, such as moving some other code around, which is pretty poor form of me sorry. Feel free to adjust this back to how it was before if you prefer.

EDIT: Should [`A_VERSION`](https://github.com/frozenpandaman/mangadex-dl/blob/1dc3e3ed16ea3d8dea37dd5e91e2a4bda7dec260/mangadex-dl.py#L5) be bumped to `0.3`?