### PR TITLE
adds case for manga not available in language

### DIFF
--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -38,6 +38,13 @@ def dl(manga_id, lang_code):
 
 	# check available chapters
 	chapters = []
+
+	if "chapter" in manga:
+		print("Chapter found in language you requested")
+	else:
+		print("Chapter not found in the language you requested.")
+		exit(1)
+
 	for chap in manga["chapter"]:
 		if manga["chapter"][str(chap)]["lang_code"] == lang_code:
 			chapters.append(manga["chapter"][str(chap)]["chapter"])


### PR DESCRIPTION
Before:
```
Traceback (most recent call last):
  File "mangadex-dl.py", line 144, in <module>
    dl(manga_id, lang_code)
  File "mangadex-dl.py", line 41, in dl
    for chap in manga["chapter"]:
KeyError: 'chapter'
```

After:
```
Chapter not found in the language you requested.
```