### PR TITLE
Explicitly use python3.

### DIFF
--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import cloudscraper
 import time, os, sys, re, json, html
 


### PR DESCRIPTION
Please see PEP394.

https://www.python.org/dev/peps/pep-0394/

You can not rely on the `python` command to be `python3` or even exist on the system.

```
Distributors may choose to set the behavior of the python command as follows:

  *      python2,
  *      python3,
  *      not provide python command,
  *      allow python to be configurable by an end user or a system administrator.

```