### PR TITLE
Skip existing downloads + fixed a small bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Python script to download manga from [MangaDex.org](https://mangadex.org/).
 
 ## Installation & usage
 ```
+$ python -m pip install requests
 $ git clone https://github.com/frozenpandaman/mangadex-dl
 $ cd mangadex-dl/
 $ python mangadex-dl.py [-l language_code] [-d] [-a]

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -192,21 +192,6 @@ def dl(manga_id, lang_code, zip_up, ds):
 		for page_filename in chapter["data"]["attributes"][datamode]:
 			images.append("{}/{}/{}/{}".format(baseurl, datamode2, chaphash, page_filename))
 
-		# get group names & make combined name
-		group_uuids = []
-		for entry in chapter["relationships"]:
-			if entry["type"] == "scanlation_group":
-				group_uuids.append(entry["id"])
-
-		groups = ""
-		for i, group in enumerate(group_uuids):
-			if i > 0:
-				groups += " & "
-			r = requests.get("https://api.mangadex.org/group/{}".format(group))
-			name = r.json()["data"]["attributes"]["name"]
-			groups += name
-		groupname = re.sub('[/<>:"/\\|?*]', '-', groups)
-
 		# download images
 		for pagenum, url in enumerate(images, 1):
 			filename = os.path.basename(url)

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -164,9 +164,9 @@ def dl(manga_id, lang_code, zip_up, ds):
 		for i, group in enumerate(group_uuids):
 			if i > 0:
 				groups += " & "
-				r = requests.get("https://api.mangadex.org/group/{}".format(group)).json()
-				name = r["data"]["attributes"]["name"]
-				groups += name
+			r = requests.get("https://api.mangadex.org/group/{}".format(group)).json()
+			name = r["data"]["attributes"]["name"]
+			groups += name
 
 		groupname = re.sub('[/<>:"/\\|?*]', '-', groups)
 		groupname = groupname if groupname else "No Group"

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -60,14 +60,18 @@ def get_uuid(manga_id):
 def get_title(uuid, lang_code):
 	r = requests.get("https://api.mangadex.org/manga/{}".format(uuid))
 	resp = r.json()
+
 	try:
 		title = resp["data"]["attributes"]["title"][lang_code]
 	except KeyError: # if no manga title in requested dl language
 		try:
 			title = resp["data"]["attributes"]["title"]["en"]
 		except:
-			print("Error - could not retrieve manga title.")
-			exit(1)
+			try:
+				title = resp["data"]["attributes"]["title"]["jp"]
+			except:
+				print("Error - could not retrieve manga title.")
+				exit(1)
 	return title
 
 def dl(manga_id, lang_code, zip_up, ds):
@@ -267,7 +271,14 @@ if __name__ == "__main__":
 		url = input("Enter manga URL or ID: ").strip()
 
 	try:
-		manga_id = url.split('/')[-1]
+		manga_id = url.split('/')
+		if len(manga_id) == 5:
+			manga_id = manga_id[-1]
+		elif len(manga_id) == 6:
+			manga_id = manga_id[-2]
+		else:
+			print("Error with URL.")
+			exit(1)
 	except:
 		print("Error with URL.")
 		exit(1)


### PR DESCRIPTION
It now doesn't download a page that already exists, or even a whole chapter if it already exists (in cbz).
And also I fixed the manga_id extraction from the url, since mangadex now includes the title of the manga in the uri.