### PR TITLE
Reducing requests, beautifying output and splitting lines

### DIFF
--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -17,7 +17,7 @@
 
 import requests, time, os, sys, re, json, html, zipfile, argparse, shutil
 
-A_VERSION = "0.6"
+A_VERSION = "0.7"
 
 def pad_filename(str):
 	digits = re.compile('(\\d+)')

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -129,7 +129,7 @@ def dl(manga_id, lang_code, zip_up, ds, outdir):
 				"&translatedLanguage[]={}&offset={}&{}"
 				.format(uuid, lang_code, offset, content_ratings))
 		chaps = r.json()
-		chap_list = chaps["data"]
+		chap_list += chaps["data"]
 		offset += 500
 
 	# chap_list is not empty at this point

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -195,17 +195,18 @@ def dl(manga_id, lang_code, zip_up, ds, outdir):
 
 		r = requests.get("https://api.mangadex.org/at-home/server/{}"
 				.format(chapter["id"]))
-		baseurl = r.json()["baseUrl"]
+		chapter_data = r.json()
+		baseurl = chapter_data["baseUrl"]
 
 		# make url list
 		images = []
 		accesstoken = ""
-		chaphash = chapter["attributes"]["hash"]
+		chaphash = chapter_data["chapter"]["hash"]
 		datamode = "dataSaver" if ds else "data"
 		datamode2 = "data-saver" if ds else "data"
 		errored = False
 
-		for page_filename in chapter["attributes"][datamode]:
+		for page_filename in chapter_data["chapter"][datamode]:
 			images.append("{}/{}/{}/{}".format(
 				baseurl, datamode2, chaphash, page_filename))
 


### PR DESCRIPTION
I noticed that there seemed to be redundant requests made for every chapter while the necessary data was already received when requesting the chapter list, so I made the necessary changes to use that instead.

While I was at it I sort of got distracted and implemented a bit more sophisticated output showing the progress of fetching the chapters, not constantly printing on new line.

Finally I decided to split the long ugly lines as according to PEP 8's guidelines.

Sidenotes:
- I concluded that there were no need to sort the chapter list in the code as the request already asks for them sorted in the desired manner, so I removed the line instead of reworking it.
- As each page iteration takes its own time already I'm quite sure we can just use 0.2 seconds of sleep instead of 0.5 without fear. I never faced a failure due to it while testing.
- I felt that there's no need to inform of the zip packaging in the output as I was not even sure how to adapt it to this new output format. Perhaps just a notice in the beginning that they're going to be packaged to .cbz files, if you feel that should be shown nevertheless? For now there's no mention of it and I found it reasonable.