### PR TITLE
Pdf creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Python script to download manga from [MangaDex.org](https://mangadex.org/).
 $ git clone https://github.com/frozenpandaman/mangadex-dl
 $ pip install requests
 $ cd mangadex-dl/
-$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir]
+$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir] [-p]
 ```
 
 You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Windows, use a backslash.
@@ -22,6 +22,7 @@ You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Wi
 * `-d`: Download page images in lower quality (higher JPG compression/"data saver").
 * `-a`: Package downloaded chapters into .cbz ([comic book archive](https://en.wikipedia.org/wiki/Comic_book_archive)) files.
 * `-o`: Use a custom output directory name to save downloaded chapters. Defaults to "download".
+* `-p`: Disables PDF creation
 
 ### Example usage
 ```

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import requests, time, os, sys, re, json, html, zipfile, argparse, shutil
+import requests, time, os, sys, re, json, html, zipfile, argparse, shutil, PIL.Image
 
 A_VERSION = "0.7"
 
@@ -93,7 +93,7 @@ def uniquify(title, chapnum, groupname, basedir):
 		counter += 1
 	return dest_folder
 
-def dl(manga_id, lang_code, zip_up, ds, outdir):
+def dl(manga_id, lang_code, zip_up, ds, outdir, make_pdf):
 	uuid = manga_id
 
 	if manga_id.isnumeric():
@@ -283,6 +283,19 @@ def dl(manga_id, lang_code, zip_up, ds, outdir):
 				print("\033[F\033[J", end='', flush=True) 
 			else:
 				print("\r\033[K", end='', flush=True)
+
+	# Creates a pdf named (Chapter.pdf) in dest_folder
+	if make_pdf:
+		with os.scandir(dest_folder) as entries:
+			img_list = []
+			pdf_location = f"{dest_folder}/Chapter.pdf"
+			for entry in entries:
+				image_location = os.path.join(dest_folder, entry.name)
+				img = PIL.Image.open(image_location)
+				img.load()
+				img_list.append(img)
+			img_list[0].save(fp=pdf_location, format="PDF", save_all=True,
+							 append_images=img_list[1:])
 	print("Done.")
 
 
@@ -302,6 +315,8 @@ if __name__ == "__main__":
 	parser.add_argument("-o", dest="outdir", required=False,
 			action="store", default="download",
 			help="specify name of output directory")
+	parser.add_argument("-p", dest="create_pdf", required=False, action="store_false",
+						help="Disables PDF creation")
 	args = parser.parse_args()
 
 	lang_code = "en" if args.lang is None else str(args.lang)
@@ -318,4 +333,4 @@ if __name__ == "__main__":
 		print("Error with URL.")
 		exit(1)
 
-	dl(manga_id, lang_code, args.cbz, args.datasaver, args.outdir)
+	dl(manga_id, lang_code, args.cbz, args.datasaver, args.outdir, args.create_pdf)


### PR DESCRIPTION
Now after downloading all the images it automatically creates a PDF using PIL.Image. So you can have your images plus a pdf of the manga. Also it doesn't need any request to mangadex so you don't have to worry about making too many requests. (If you don't want a PDF you can use "-p" as an argument in the terminal and no pdf will be added)
There is an issue requesting this feature #49
On the other hand, there is also an issue about skipping chapters that have already been downloaded #39. I didn't add that solution to this pull request because I thought you wanted to be able to download the chapters twice, but if you want me to add that feature just ask me and I'll send you another PR because it's easy to implement.