### PR TITLE
New features: pdf flag, skip flag, remove flag and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A Python script to download manga from [MangaDex.org](https://mangadex.org/).
 ## Installation & usage
 ```
 $ git clone https://github.com/frozenpandaman/mangadex-dl
-$ pip install requests
+$ pip install -r requirements.txt
 $ cd mangadex-dl/
-$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir] [-p]
+$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir] [-p] [-r]
 ```
 
 You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Windows, use a backslash.
@@ -20,9 +20,11 @@ You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Wi
 
 * `-l`: Download releases in a language other than English. For a list of language codes, see the [wiki page](https://github.com/frozenpandaman/mangadex-dl/wiki/language-codes).
 * `-d`: Download page images in lower quality (higher JPG compression/"data saver").
-* `-a`: Package downloaded chapters into .cbz ([comic book archive](https://en.wikipedia.org/wiki/Comic_book_archive)) files.
+* `-a`: Makes a copy of the downloaded chapter in a .cbz ([comic book archive](https://en.wikipedia.org/wiki/Comic_book_archive)) file.
 * `-o`: Use a custom output directory name to save downloaded chapters. Defaults to "download".
-* `-p`: Disables PDF creation
+* `-p`: Makes a copy of the downloaded chapter in a .pdf file
+* `-r`: Deletes the downloaded chapter directory, leaving the created pdf/cbz files in place (only works if the `-p` and/or `-a` flag is also used).
+* `-s`: Skip the chapter if it is already downloaded (if it is partially downloaded it will continue from where it left off).
 
 ### Example usage
 ```
@@ -47,6 +49,20 @@ Downloading chapter 1...
 ... (and so on)
 ```
 
+###Config file
+* You can use the `config.txt` file to select the flags and, therefore, it is not necessary to put them in the command line.
+* The settings on the config.txt will overwrite your flags written on the command line so take that in count.
+* Config.txt doesn't read the command if at the begging has a `#`. And doesn't care about spaces.
+###Config file Example
+```
+language = "es" 
+datasaver = False
+cbz = True
+pdf = True
+remove = False
+skip = True
+outdir = "mycool/directory/foo/bar"
+```
 ### Current limitations
  * The script will download all available releases (in your language) of each chapter specified.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Python script to download manga from [MangaDex.org](https://mangadex.org/).
 $ git clone https://github.com/frozenpandaman/mangadex-dl
 $ pip install requests
 $ cd mangadex-dl/
-$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir]
+$ python mangadex-dl.py [-l language_code] [-d] [-a] [-o dl_dir] [-p]
 ```
 
 You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Windows, use a backslash.
@@ -22,6 +22,7 @@ You can also execute the script via `./mangadex-dl.py` on macOS and Linux. On Wi
 * `-d`: Download page images in lower quality (higher JPG compression/"data saver").
 * `-a`: Package downloaded chapters into .cbz ([comic book archive](https://en.wikipedia.org/wiki/Comic_book_archive)) files.
 * `-o`: Use a custom output directory name to save downloaded chapters. Defaults to "download".
+* `-p`: Disables PDF creation
 
 ### Example usage
 ```

--- a/config.txt
+++ b/config.txt
@@ -1,0 +1,9 @@
+# Delete the "#" at the beggining and add your values
+# WARNING THIS WILL OVERRIDE YOUR FLAGS
+# language = "en"
+# datasaver = True
+# cbz = True
+# pdf = True
+# remove = True
+# skip = True
+# outdir = ""

--- a/mangadex-dl.py
+++ b/mangadex-dl.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import requests, time, os, sys, re, json, html, zipfile, argparse, shutil
+import requests, time, os, sys, re, json, html, zipfile, argparse, shutil, PIL.Image
 
 A_VERSION = "0.7"
 
@@ -93,7 +93,7 @@ def uniquify(title, chapnum, groupname, basedir):
 		counter += 1
 	return dest_folder
 
-def dl(manga_id, lang_code, zip_up, ds, outdir):
+def dl(manga_id, lang_code, zip_up, ds, outdir, make_pdf):
 	uuid = manga_id
 
 	if manga_id.isnumeric():
@@ -283,6 +283,19 @@ def dl(manga_id, lang_code, zip_up, ds, outdir):
 				print("\033[F\033[J", end='', flush=True) 
 			else:
 				print("\r\033[K", end='', flush=True)
+
+	# Creates a pdf named (Chapter.pdf) in dest_folder
+	if make_pdf:
+		with os.scandir(dest_folder) as entries:
+			img_list = []
+			pdf_location = f"{dest_folder}/Chapter.pdf"
+			for entry in entries:
+				image_location = os.path.join(dest_folder, entry.name)
+				img = PIL.Image.open(image_location)
+				img.load()
+				img_list.append(img)
+			img_list[0].save(fp=pdf_location, format="PDF", save_all=True,
+							 append_images=img_list[1:])
 	print("Done.")
 
 
@@ -302,6 +315,8 @@ if __name__ == "__main__":
 	parser.add_argument("-o", dest="outdir", required=False,
 			action="store", default="download",
 			help="specify name of output directory")
+	parser.add_argument("-p", dest="create_pdf", required=False, action="store_false",
+						help="Disables PDF creation")
 	args = parser.parse_args()
 
 	lang_code = "en" if args.lang is None else str(args.lang)
@@ -318,4 +333,4 @@ if __name__ == "__main__":
 		print("Error with URL.")
 		exit(1)
 
-	dl(manga_id, lang_code, args.cbz, args.datasaver, args.outdir)
+	dl(manga_id, lang_code, args.cbz, args.datasaver, args.outdir, args.create_pdf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pillow
+configargparse


### PR DESCRIPTION
New features: pdf flag #49 , skip flag, remove flag and config file.
Basically what the title says you can now convert images to pdf using "pillow". Also use configuration files using "ConfigArgParse". As it is necessary to install these three new packages (including requests) I decided to create a `requirements.txt` file. Also added the option to skip, so if you activate it the same chapter will not be downloaded again (Except if the chapter was uploaded by a different translators).
Other features: Now it doesn't use Argparse but configargparse so you can have a config file (works the same as argparse but with config file support so there is no change in the code itself apart from the import).
Also now when you try to download something using cbz the directory is not auto-deleted, instead the cbz file is saved inside the directory. But if you use the -remove or -r flag the directory will delete itself and the cbz file will take its place (pdf works similarly).
Side note: The remove flag is hardcoded so that it cannot be set unless the pdf and/or the cbz file are set to avoid useless requests to mangadex.
Sorry for the pessimal grammar but this PR is being made at midnight because I was having a hard time figuring how to update the contents of a Pull requests (and that's why I had 2 PR with the exact same content, that were closed inmmediately after being uploaded). 